### PR TITLE
remove the cache time 

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,5 @@ auth:
     url: https://your-auth-api/
     user_key: name # username field, default: username
     pwd_key: password # password field, default: password
-    cache: 30 # auth status cache, default: 30s
     email: gmail.com # NPM does not allow user names to contain `@`, if your user name is a mailbox, you can write a suffix. 
 ```

--- a/index.js
+++ b/index.js
@@ -2,47 +2,41 @@ const axios = require('axios')
 
 module.exports = DelegatedAuthentication
 
-const DEFAULT_CACHE = 30
-let ch = {}
-
 function DelegatedAuthentication(config, stuff) {
-  var self = Object.create(DelegatedAuthentication.prototype)
+    var self = Object.create(DelegatedAuthentication.prototype)
 
-  // config for this module
-  self._config = config
-  self._logger = stuff.logger
-  self._logger.warn('Auth plugin configuration:\n', config)
+    // config for this module
+    self._config = config
+    self._logger = stuff.logger
+    self._logger.warn('Auth plugin configuration:\n', config)
 
-  var url = self._config.url
-  if (!url) throw new Error('should specify "url" in config')
+    var url = self._config.url
+    if (!url) throw new Error('should specify "url" in config')
 
-  return self
+    return self
 }
 
 DelegatedAuthentication.prototype.authenticate = function (user, password, cb) {
-  let self = this
-  let params = {}
-  let _user = this._config.email ? `${user}@${this._config.email}` : user
-  params[this._config.user_key || 'username'] = _user
-  params[this._config.pwd_key || 'password'] = password
-  if(ch[user] && ch[user] > new Date().getTime()) {
-    return cb(null, [user])
-  } else {
+    let self = this
+    let params = {}
+    let _user = this._config.email ? `${ user }@${ this._config.email }` : user
+    params[this._config.user_key || 'username'] = _user
+    params[this._config.pwd_key || 'password'] = password
+
     self._logger.warn('Authentication request: ', _user)
     axios.post(self._config.url, params)
-    .then(function (res) {
-      if(res.data.error) { // json-rpc error
-        self._logger.warn('Authentication failed. ', res.data.error.code ?  `code: ${res.data.error.code}` : 'not error code')
-        return cb(null, false)
-      } else { // success: supports API style for RESTful and JSON-rpc
-        self._logger.warn('Authentication succeeded')
-        ch[user] = new Date().getTime() + 1000 * (self._config.cache || DEFAULT_CACHE)
-        return cb(null, [user])
-      }
-    })
-    .catch(function (error) {
-      self._logger.warn('Authentication failed: ', _user)
-      return cb(null, false)
-    });
-  }
+        .then(function (res) {
+            if (res.data.error) { // json-rpc error
+                self._logger.warn('Authentication failed. ', res.data.error.code ? `code: ${ res.data.error.code }` : 'not error code')
+                return cb(null, false)
+            } else { // success: supports API style for RESTful and JSON-rpc
+                self._logger.warn('Authentication succeeded')
+                return cb(null, [user])
+            }
+        })
+        .catch(function (error) {
+            self._logger.warn('Authentication failed: ', _user)
+            return cb(null, false)
+        })
+
 }


### PR DESCRIPTION
Because the script is running on the node, so the cache will be always, so if the user has logined success once, the other people who have no perssion will be able to access

兄dei，你这个脚本是跑在node上的，你这里用一个cache来减少重复校验，在demaon状态下，这个ch变量将会一直存在，这就意味着如果有用户登陆过自己的账号，这个ch变将他记录了，之后其他人登录的时候，第一次将校验失败，第二次将会直接无需密码就可校验成功，因为ch此时是有登录成功的用户名的，其他人登录该用户名在失败后可无需正确密码登录该用户名